### PR TITLE
Add nodejs v12 is required in readme for sha3-256

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,14 @@ Libra Core [js] is a javascript library client that can be used to interact with
 
 The end goal is to make it usable both in node and on browser clients too, but currently it is mostly compatible with node.
 
+## Prepare
+- Node ~v12.6.0 is reuiqred for sha3-256.
+You can use nvm to download/use node v12 by following.
+```sh
+nvm install 12
+nvm use 12
+```
+
 ## Installation
 To install with npm run:
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Libra Core [js] is a javascript library client that can be used to interact with
 The end goal is to make it usable both in node and on browser clients too, but currently it is mostly compatible with node.
 
 ## Prepare
-- Node ~v12.6.0 is reuiqred for sha3-256.
+- Node ^v12.0.0 is reuiqred for sha3-256.
 You can use nvm to download/use node v12 by following.
 ```sh
 nvm install 12

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "libra-core",
   "version": "1.0.0-alpha",
   "description": "Library for Crypto",
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "engineStrict": true,
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
I've faced error when using node below 12.
```
TypeError [ERR_CRYPTO_INVALID_DIGEST]: Invalid digest: **sha3-256**
```
It take me for a while to figure it out that **sha3-256** is not included in nodejs prior to v12.
So it should save time for other guys if we just notice about this in readme.