### PR TITLE
Fix HTTP method to POST for faucet

### DIFF
--- a/lib/client/index.ts
+++ b/lib/client/index.ts
@@ -182,7 +182,7 @@ export class LibraClient {
     const serverHost = this.config.faucetServerHost || ServerHosts.DefaultFaucet;
     const coins = new BigNumber(numCoins).toString(10);
     const address = receiver.toString();
-    const response = await axios.get(`http://${serverHost}?amount=${coins}&address=${address}`);
+    const response = await axios.post(`http://${serverHost}?amount=${coins}&address=${address}`);
 
     if (response.status !== 200) {
       throw new Error(`Failed to query faucet service. Code: ${response.status}, Err: ${response.data.toString()}`);


### PR DESCRIPTION
Fix #35 

```js
$ node
Welcome to Node.js v12.7.0.
Type ".help" for more information.
> const libra_core = require("libra-core");
undefined
> const LibraWallet = libra_core.LibraWallet;
undefined
> const LibraAccount = libra_core.Account;
undefined
> const LibraClient = libra_core.LibraClient;
undefined
> const LibraNetwork = libra_core.LibraNetwork;
undefined
> const wallet = new LibraWallet();
undefined
> const account = wallet.newAccount();
undefined
> const client = new LibraClient({ network: LibraNetwork.Testnet });
undefined
> client.mintWithFaucetService(account.getAddress(), 1e6).then(r => console.log(r)).catch(e => console.error(e));
Promise { <pending> }
Error: Confirmation timeout for [0000000000000000000000000000000000000000000000000000000000000000]:[134]
    at /Users/r17n/development/libra-nodejs/node_modules/libra-core/build/client/index.js:152:32
> account.getAddress().toString()
'701a696e850014f27bfd428d049ff64f0f9bee5b64ddd4add7fe139ce7216707'
```

https://libexplorer.com/address/701a696e850014f27bfd428d049ff64f0f9bee5b64ddd4add7fe139ce7216707