### PR TITLE
add const wallet in example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,9 @@ import { LibraClient, LibraNetwork } from 'libra-core';
 
 async function main() {
   const client = new LibraClient({ network: LibraNetwork.Testnet });
-
+  const wallet = new LibraWallet({
+          mnemonic: 'upgrade salt toy stable drop paddle'
+        });
   const account = wallet.newAccount();
 
   // mint 2 libracoins to users accounts


### PR DESCRIPTION
The Readme.md example code for minting libra doesn't create the wallet variable. This update adds that so the example works.